### PR TITLE
Apply documentation assessment improvements across 13 pages

### DIFF
--- a/docs/configuration/opcon-database-connection.md
+++ b/docs/configuration/opcon-database-connection.md
@@ -20,7 +20,7 @@ OpCon uses a single database to manage all scheduling data. The Fiserv DNA Conne
 
 Complete all three tasks before moving to the next configuration step.
 
-## Step 1 — Copy the OpCon database connection file
+## Copy the OpCon database connection file
 
 To copy the OpCon database connection file to the DNA folder, complete the following steps:
 
@@ -30,7 +30,7 @@ To copy the OpCon database connection file to the DNA folder, complete the follo
 4. Go to `<media>:\ProgramData\OpConxps\DNA\`.
 5. Paste the file in this directory.
 
-## Step 2 — Update the SMA Request Router INI
+## Update the SMA Request Router INI
 
 The SMA Request Router needs a new entry so it knows how to route DNA job requests to the DNA Query Processor (`SMADNAQueryProcessor.exe`).
 
@@ -62,7 +62,9 @@ To update the SMA Request Router INI file, complete the following steps:
 | `RequestExecutionPath` | The DNA installation directory (the working directory for the request handler). |
 | `RequestArguments` | Arguments for the request handler executable's command line. |
 
-## Step 3 — Update the OpCon database
+7. Return to **Services** and start the **SMA Service Manager** service.
+
+## Update the OpCon database
 
 This step inserts the records that tell OpCon's database about the DNA Query Processor. The script removes any existing records first to avoid duplicates, then inserts fresh ones.
 

--- a/docs/configuration/sma-run-dna-job-program.md
+++ b/docs/configuration/sma-run-dna-job-program.md
@@ -94,7 +94,7 @@ The General settings control core program behavior — log retention, the SQRWT 
 |---|---|---|
 | `DaysOfLogFilesToKeep` | No | Number of days to retain log files. Log files older than this value are purged automatically. |
 | `Program2Execute` | Yes | Full path to the SQRWT program (`sqrwt.exe` or `sqrt.exe`). |
-| `SQTArgumentTemplate` | No | Template for building SQRWT arguments. Use double-bracket property tokens (for example, `[[SCHEDDATE]]`) for dynamic values. |
+| `SQTArgumentTemplate` | No | Template for building the SQRWT command-line argument string. Supported tokens are replaced at run time: `[[SQTPath]]`, `[[SQTUser]]`, `[[SQTPassword]]`, `[[SQTDatabase]]`, `[[SQTOptions]]`, `[[SQTErrorFile]]`, `[[SQTResponseFile]]`. |
 | `EnvFile` **†** | No | Full path to the environment file that sets up the execution environment for SQRWT. See [Environment file](../reference/environment-file.md). |
 | `ErrorWordsFile` **†** | No | Full path to `SMAErrorWordsFile.txt`. Rows in the DNA error table matching these expressions cause the job to fail. See [SMAErrorWordsFile](../reference/sma-error-words-file.md). |
 
@@ -165,7 +165,7 @@ Use DriveMappings when SMARunDNAJob needs to connect to network shares as mapped
 
 | Setting | Required | Description |
 |---|---|---|
-| `Drive1`…`Drive999` | No | Drive mapping definition. Each value contains four fields separated by a pipe (`\|`): local drive letter, share name, user name, encrypted user password. For example: `Z:\|\\server\share\|domain\user\|encryptedpassword`. |
+| `Drive1`…`Drive99` | No | Drive mapping definition. Each value contains four fields separated by a pipe (`\|`): local drive letter, share name, user name, encrypted user password. For example: `Z:\|\\server\share\|domain\user\|encryptedpassword`. |
 
 ## Output File Handling
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,14 @@
 ---
 slug: '/'
+title: Fiserv DNA Connector
 sidebar_label: 'DNA Connector'
+description: "Documentation for the Fiserv DNA Connector for OpCon — installation, configuration, and reference for all components."
 hide_table_of_contents: true
 displayed_sidebar: null
+tags:
+  - Conceptual
+  - All
+  - DNA Connector
 ---
 
 # Fiserv DNA Connector

--- a/docs/installation/convert-dna-template-program.md
+++ b/docs/installation/convert-dna-template-program.md
@@ -17,12 +17,13 @@ The Convert DNA Template program (`SMAConvertDNATemplate.exe`) imports existing 
 ## Prerequisites
 
 - The machine has network access to the Fiserv DNA Oracle database.
+- .NET Framework 4.7 is installed on the machine.
 - The DDI (Data Definition Interface) service is running on the OpCon server and its hot folder path is known.
 
 ## Install the Convert DNA Template program
 
 To install the Convert DNA Template program, complete the following steps:
 
-1. Copy `SMAConvertDNATemplate.exe` and its supporting files to the directory where the program will run and connect to the Fiserv database. For example: `C:\SMADNA`.
+1. Copy `SMAConvertDNATemplate.exe` and its supporting files to the directory where the program will run and connect to the Fiserv DNA Oracle database. For example: `C:\SMADNA`.
 
 After installation, proceed to [Convert DNA Template usage](../convert-dna-template.md) to configure and run the program.

--- a/docs/installation/sma-run-dna-job-program.md
+++ b/docs/installation/sma-run-dna-job-program.md
@@ -19,6 +19,7 @@ SMARunDNAJob is the program that starts and monitors Fiserv DNA jobs. Install it
 - SQRWT (`sqrwt.exe`) is installed and accessible on the target machine.
 - ODAC (Oracle Data Access Components) is installed on the target machine.
 - Oracle client software (administrator edition) is installed on the target machine.
+- .NET 5.0 runtime (Windows x64) is installed on the target machine.
 
 ## Install SMARunDNAJob
 

--- a/docs/overview/fiserv-dna-subtype.md
+++ b/docs/overview/fiserv-dna-subtype.md
@@ -25,8 +25,8 @@ The **Job Details** tab provides fields for the DNA job's core identifying infor
 - **APPL name** — The name of the Fiserv DNA application (APPL) to run.
 - **APPL number** — The numeric identifier for the Fiserv DNA application.
 - **Effective date** — The processing date for the DNA job, in `YYYY/MM/DD` format.
-
-Additional DNA-specific fields are available depending on the job type.
+- **Cycle codes** — One or more Fiserv DNA processing cycle identifiers for the job (for example, `EOM` for end-of-month). Cycle codes correspond to the `-C1` through `-C99` command-line arguments.
+- **Parameters** — DNA job parameters passed to the job at run time. Parameters correspond to the `-P1` through `-P99` command-line arguments and follow the format `PARAMETER_CODE|value`.
 
 ![DNA job definition - Job Details tab](../../static/img/dna-job-definition-1.png)
 
@@ -34,7 +34,7 @@ Additional DNA-specific fields are available depending on the job type.
 
 The **Job DNA Query** tab lets you query the Fiserv DNA database directly from within OpCon to look up job definitions and auto-populate the job detail fields.
 
-To use the query:
+To query the Fiserv DNA database, complete the following steps:
 
 1. Select a template or APPL from the list.
 2. Review the APPL details, including parameter codes, parameter code descriptions, data types, and default database values.

--- a/docs/overview/sma-run-dna-job-program.md
+++ b/docs/overview/sma-run-dna-job-program.md
@@ -16,7 +16,24 @@ SMARunDNAJob is a command-line program that starts and monitors jobs on the Fise
 
 An enhanced monitoring option provides visibility into the job's status as it runs by tracking the active Oracle session associated with the DNA process.
 
-If the job completes without errors, SMARunDNAJob exits with code `0` and OpCon marks the job finished. If the job encounters errors, SMARunDNAJob exits with a non-zero code and OpCon marks the job failed.
+SMARunDNAJob exits with one of the following codes:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Job completed successfully. |
+| `1` | Job failed. Check the log file for details. |
+| `5001` | File-load job completed with `TBL` (partial load) status rather than full `LOAD` status. |
+
+## File-load jobs
+
+A file-load job is a special DNA job type that processes a file into the Fiserv DNA system. Use the `-FileLoad` command-line argument to run a job in file-load mode. SMARunDNAJob tracks five counters for the file-load operation — batch count, record count, credits, debits, and file number — and stores each in an OpCon property you specify on the command line.
+
+When the file-load job completes, DNA reports one of two statuses:
+
+- **LOAD** — The file was fully loaded. SMARunDNAJob exits with code `0`.
+- **TBL** — The file was partially loaded (table load only). SMARunDNAJob exits with code `5001`.
+
+See [Command-line options](../reference/command-line.md) for the `-FileLoad` and related arguments.
 
 ## How it works
 

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -5,7 +5,7 @@ description: "Complete reference for all command-line arguments accepted by SMAR
 tags:
   - Reference
   - Developer
-  - Reference
+  - DNA Connector
 ---
 
 # SMARunDNAJob command-line options
@@ -23,7 +23,7 @@ SMARunDNAJob accepts command-line arguments that override or supplement the sett
 | `-ApplNumber` | Either `-ApplName` or `-ApplNumber` | APPL number. When specified, SMARunDNAJob uses this number directly instead of performing a database lookup. Some APPLs have multiple APPL numbers; specifying the number on the command line ensures the correct one is used. |
 | `-CreateFolderWithEDandQN` | No | Path to which the effective date and queue number are appended. SMARunDNAJob creates the resulting directory structure. The root directory must already exist. |
 | `-CycleCodeNotRequired` | No | Allows a job with defined cycle codes in the database to run without any cycle codes specified on the command line. No value is required — specify `-CycleCodeNotRequired` alone. Has no effect if the job has no cycle codes. |
-| `-EffectiveDate` | No | Effective date for the DNA job. Must be in `YYYY/MM/DD` format. If not specified, the value is retrieved from the `BANKOPTION` table. |
+| `-EffectiveDate` | No | Effective date for the DNA job. Must be in `YYYY/MM/DD` format. If not specified, SMARunDNAJob retrieves the effective date from the `PDAT` field in the `BANKOPTION` table. |
 | `-EffectiveDateOffset` | No | A positive or negative integer added to the effective date. |
 | `-FileLoad` | No | Indicates a FileLoad job. Format: `-FileLoad="filename"`. When specified, you must also supply the FileLoad arguments listed below. |
 | `-FLBatchCount` | Required with `-FileLoad` | Name of the OpCon property to store the batch count from the file load. |
@@ -38,6 +38,26 @@ SMARunDNAJob accepts command-line arguments that override or supplement the sett
 | `-Property4QueueID` | No | Name of the OpCon property in which to save the queue ID for later reference. |
 | `-PVSeparator` | No | Alternate separator character to use in parameter specifications instead of the vertical pipe (`\|`). |
 | `-UseBusinessDate` | No | Instructs SMARunDNAJob to look up the business date in the `BANKORGYEARMONTHDAY` table using the effective date. Requires `-EffectiveDate`. If `-EffectiveDateOffset` is also set, the offset is applied in business days. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Job completed successfully. |
+| `1` | Job failed. Check the SMARunDNAJob log file for details. |
+| `5001` | File-load job completed with `TBL` (partial load) status. The file was processed but did not reach full `LOAD` status. Review the DNA job output to determine whether the partial load is acceptable. |
+
+## Test and debug options
+
+These options are intended for testing and troubleshooting only. Do not use them in production job definitions.
+
+| Option | Required | Description |
+|---|---|---|
+| `-TestMode` | No | Skips actual SQRWT execution. |
+| `-TestApplNumber` | No | Generates a synthetic APPL number from the current timestamp instead of performing a database lookup. |
+| `-TestQueueNumber` | No | Generates a synthetic queue number from the current timestamp instead of retrieving one from the DNA database. |
+| `-TestSimulateOracleMonitor` | No | Instructs the Oracle session monitor to always report the job as running. Useful for testing monitoring logic without an active Oracle session. |
+| `-Debug` | No | Enables verbose debug output. |
 
 ## Parameter format
 

--- a/docs/reference/environment-file.md
+++ b/docs/reference/environment-file.md
@@ -5,7 +5,7 @@ description: "Reference for the SMARunDNAJob environment file format, including 
 tags:
   - Reference
   - Developer
-  - Reference
+  - DNA Connector
 ---
 
 # Environment file

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -5,7 +5,7 @@ description: "An overview of the reference material available for the Fiserv DNA
 tags:
   - Reference
   - All
-  - Reference
+  - DNA Connector
 ---
 
 # Reference overview

--- a/docs/reference/sma-error-words-file.md
+++ b/docs/reference/sma-error-words-file.md
@@ -5,7 +5,7 @@ description: "Reference for the SMAErrorWordsFile.txt format used by SMARunDNAJo
 tags:
   - Reference
   - Developer
-  - Reference
+  - DNA Connector
 ---
 
 # SMAErrorWordsFile

--- a/docs/reference/troubleshooting-tips.md
+++ b/docs/reference/troubleshooting-tips.md
@@ -5,7 +5,7 @@ description: "Troubleshooting guidance for common Fiserv DNA Connector issues, i
 tags:
   - Reference
   - System Administrator
-  - Reference
+  - DNA Connector
 ---
 
 # Troubleshooting tips
@@ -18,7 +18,12 @@ This page provides solutions to common issues encountered when installing, confi
 
 **Issue: After extracting the connector files, the application does not run or returns a security error.**
 
-Run the following check after extraction: right-select each file, select **Properties**, and verify the file is not blocked by Windows. If a file is blocked, select **Unblock** in the **Properties** dialog, then select **OK**.
+To unblock the connector files, complete the following steps:
+
+1. Right-select the file and select **Properties**.
+2. In the **Properties** dialog, verify whether the file is blocked by Windows.
+3. If the file is blocked, select **Unblock**, then select **OK**.
+4. Repeat for each file in the extracted connector package.
 
 ## Fiserv DNA sub-type
 
@@ -72,6 +77,31 @@ HostName=dnacreator
 Port=1521
 ServiceName=neondna4
 ```
+
+## SMARunDNAJob
+
+**Issue: A DNA job exits with code 5001.**
+
+Exit code 5001 indicates a file-load job completed with `TBL` (partial load) status rather than full `LOAD` status. This is not a connector error — it means the DNA job ran but the file was not fully loaded into the DNA system. Review the DNA job output and SQRWT error file to determine whether the partial load is acceptable for your workflow. If `LOAD` status is required, investigate the source file or DNA processing configuration.
+
+**Issue: SMARunDNAJob exits with code 1 immediately after starting.**
+
+Verify the following:
+
+1. Confirm `Program2Execute` in `SMARunDNAJob.ini` points to the correct path for `sqrwt.exe` or `sqrt.exe`.
+2. Confirm the APPL name or APPL number specified on the command line exists in the Fiserv DNA database.
+3. Check the SMARunDNAJob log file (in the same directory as `SMARunDNAJob.exe`, named after the APPL) for the specific error message.
+4. Confirm ODAC is installed and the ODAC version matches the Oracle client version on the machine.
+
+**Issue: Oracle session monitoring reports the job as lost before the job finishes.**
+
+If SMARunDNAJob fails jobs that are still running in DNA, the `LostSessionTimeoutSeconds` value may be too short, or the `MachineName` setting may not match the `TERMINAL` field in the Oracle `V$SESSION` table.
+
+To diagnose:
+
+1. Check the `MachineName` setting in `SMARunDNAJob.ini`. If not set, SMARunDNAJob uses the `COMPUTERNAME` environment variable. Confirm this value matches the `TERMINAL` column in `V$SESSION` for your Oracle environment.
+2. Increase `LostSessionTimeoutSeconds` to allow more time before declaring a session lost.
+3. If the Oracle environment uses multiple nodes (RAC), set `Cluster=true` so SMARunDNAJob queries `GV$SESSION` instead of `V$SESSION`.
 
 ## FAQs
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,10 @@ tags:
 
 # DNA Connector release notes
 
+## What is it?
+
+This page documents version history for the Fiserv DNA Connector, including new features, improvements, and bug fixes by release.
+
 ## 26
 
 ### 26.0.0


### PR DESCRIPTION
## Summary

- **Standards fixes** — corrected duplicate tags on 5 reference pages, fixed a procedure lead-in sentence, replaced `Step N —` H2 headings with descriptive names, added a missing `What is it?` section to release notes, and added complete front matter to the landing page
- **Factual corrections** — fixed Drive mapping limit (Drive999 → Drive99), corrected database name wording, documented the `PDAT` field as the effective date source in `BANKOPTION`, and updated `SQTArgumentTemplate` to list all supported tokens
- **Content additions (all confirmed against Connector-DNA codebase)** — added .NET 5.0 and .NET Framework 4.7 prerequisites to installation pages, added exit codes table (0 / 1 / 5001) and file-load mode conceptual section, documented test/debug command-line arguments, expanded the Job Details tab field list to include cycle codes and parameters, added a missing restart step to the Request Router procedure, and added three new troubleshooting scenarios (exit code 5001, immediate exit 1 diagnostic, Oracle session monitoring)

## Test plan

- [ ] Confirm Docusaurus builds without errors (`yarn start`)
- [ ] Verify all internal links resolve correctly
- [ ] Confirm Drive mapping table shows Drive1…Drive99
- [ ] Confirm exit codes table appears on both the overview and command-line reference pages
- [ ] Confirm test/debug arguments section is visible in command-line reference
- [ ] Confirm step 7 (restart service) appears after the settings table in the Request Router procedure
- [ ] Confirm .NET prerequisites appear on both installation pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)